### PR TITLE
Better auto thread names

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"node-fetch": "^3.2.0",
 		"rimraf": "^3.0.2",
 		"typescript": "^4.5.5",
+		"unfurl.js": "^5.6.3",
 		"url-regex": "^5.0.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ specifiers:
   prettier: ^2.5.1
   rimraf: ^3.0.2
   typescript: ^4.5.5
+  unfurl.js: ^5.6.3
   url-regex: ^5.0.0
 
 dependencies:
@@ -27,6 +28,7 @@ dependencies:
   node-fetch: 3.2.0
   rimraf: 3.0.2
   typescript: 4.5.5
+  unfurl.js: 5.6.3
   url-regex: 5.0.0
 
 devDependencies:
@@ -251,6 +253,10 @@ packages:
       fill-range: 7.0.1
     dev: true
 
+  /buffer-from/1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: false
+
   /bufferutil/4.0.6:
     resolution: {integrity: sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==}
     engines: {node: '>=6.14.2'}
@@ -420,7 +426,6 @@ packages:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     dependencies:
       ms: 2.1.3
-    dev: true
 
   /decompress-response/3.3.0:
     resolution: {integrity: sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=}
@@ -474,6 +479,34 @@ packages:
       - utf-8-validate
     dev: false
 
+  /dom-serializer/0.2.2:
+    resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==}
+    dependencies:
+      domelementtype: 2.2.0
+      entities: 2.2.0
+    dev: false
+
+  /domelementtype/1.3.1:
+    resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
+    dev: false
+
+  /domelementtype/2.2.0:
+    resolution: {integrity: sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==}
+    dev: false
+
+  /domhandler/2.4.2:
+    resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==}
+    dependencies:
+      domelementtype: 1.3.1
+    dev: false
+
+  /domutils/1.7.0:
+    resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
+    dependencies:
+      dom-serializer: 0.2.2
+      domelementtype: 1.3.1
+    dev: false
+
   /dot-prop/5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -499,6 +532,14 @@ packages:
     dependencies:
       once: 1.4.0
     dev: true
+
+  /entities/1.1.2:
+    resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
+    dev: false
+
+  /entities/2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+    dev: false
 
   /error-ex/1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -764,13 +805,36 @@ packages:
       function-bind: 1.1.1
     dev: true
 
+  /he/1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+    dev: false
+
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
 
+  /htmlparser2/3.10.1:
+    resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
+    dependencies:
+      domelementtype: 1.3.1
+      domhandler: 2.4.2
+      domutils: 1.7.0
+      entities: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+    dev: false
+
   /http-cache-semantics/4.1.0:
     resolution: {integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==}
     dev: true
+
+  /iconv-lite/0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
 
   /ignore-by-default/1.0.1:
     resolution: {integrity: sha1-SMptcvbGo68Aqa1K5odr44ieKwk=}
@@ -1093,7 +1157,6 @@ packages:
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
   /next-tick/1.0.0:
     resolution: {integrity: sha1-yobR/ogoFpsBICCOPchCS524NCw=}
@@ -1326,6 +1389,15 @@ packages:
       path-type: 3.0.0
     dev: true
 
+  /readable-stream/3.6.0:
+    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: false
+
   /readdirp/3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -1367,6 +1439,14 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.0
+    dev: false
+
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
+
+  /safer-buffer/2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: false
 
   /semver-diff/3.1.1:
@@ -1422,6 +1502,18 @@ packages:
     resolution: {integrity: sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==}
     dev: true
 
+  /source-map-support/0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: false
+
+  /source-map/0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /spdx-correct/3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
     dependencies:
@@ -1475,6 +1567,12 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.3
     dev: true
+
+  /string_decoder/1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
 
   /strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1585,6 +1683,20 @@ packages:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: true
 
+  /unfurl.js/5.6.3:
+    resolution: {integrity: sha512-UO0iYgN0Iwn3D6AovfX7A1X7c2bqZHX5VdkENiGIi2mY+dth93RbHFh7Vs/lldoVKQFleLiZv/0W73sp6wvoQQ==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      debug: 3.2.7
+      he: 1.2.0
+      htmlparser2: 3.10.1
+      iconv-lite: 0.4.24
+      node-fetch: 2.6.7
+      source-map-support: 0.5.21
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /unique-string/2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
@@ -1633,6 +1745,10 @@ packages:
     requiresBuild: true
     dependencies:
       node-gyp-build: 4.3.0
+    dev: false
+
+  /util-deprecate/1.0.2:
+    resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
     dev: false
 
   /validate-npm-package-license/3.0.4:

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -1,3 +1,5 @@
+import { getTitleFromUrl } from '../utils/unfurl.js';
+import type { Message } from 'discord.js';
 import { event } from 'jellycommands';
 import urlRegex from 'url-regex';
 
@@ -46,13 +48,29 @@ export default event({
 			message.channel.type == 'GUILD_TEXT'
 		) {
 			try {
-				message.channel.threads.create({
-					name: 'Discussion',
+				const thread = await message.channel.threads.create({
+					name: 'Loading Name...',
 					startMessage: message,
 				});
+
+				// Generate the thread name after so that the thread creates faster
+				await thread.setName(await getThreadName(message));
 			} catch {
 				// we can ignore this error since chances are it will be that thread already exists
 			}
 		}
 	},
 });
+
+async function getThreadName(message: Message): Promise<string> {
+	const url = message.content.match(urlRegex());
+
+	// If the channel isn't a link channel (i.e. a question one) or url can't be matched
+	if (!LINK_ONLY_CHANNELS.includes(message.channelId) || !url)
+		return `Q - ${message.content.slice(0, 32)}`;
+
+	const urlName = await getTitleFromUrl(url[0]);
+
+	// Return the urlname and fallback to discussion
+	return urlName || 'Discussion';
+}

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -1,4 +1,4 @@
-import { getTitleFromUrl } from '../utils/unfurl.js';
+import { get_title_from_url } from '../utils/unfurl.js';
 import type { Message } from 'discord.js';
 import { event } from 'jellycommands';
 import urlRegex from 'url-regex';
@@ -54,7 +54,7 @@ export default event({
 				});
 
 				// Generate the thread name after so that the thread creates faster
-				await thread.setName(await getThreadName(message));
+				await thread.setName(await get_thread_name(message));
 			} catch {
 				// we can ignore this error since chances are it will be that thread already exists
 			}
@@ -62,12 +62,12 @@ export default event({
 	},
 });
 
-function getThreadName(message: Message): string | Promise<string> {
+function get_thread_name(message: Message): string | Promise<string> {
 	const url = message.content.match(urlRegex());
 
 	// If the channel isn't a link channel (i.e. a question one) or url can't be matched
 	if (!LINK_ONLY_CHANNELS.includes(message.channelId) || !url)
 		return `Q - ${message.content.slice(0, 22)}`;
 
-	return getTitleFromUrl(url[0]);
+	return get_title_from_url(url[0]);
 }

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -67,7 +67,7 @@ async function getThreadName(message: Message): Promise<string> {
 
 	// If the channel isn't a link channel (i.e. a question one) or url can't be matched
 	if (!LINK_ONLY_CHANNELS.includes(message.channelId) || !url)
-		return `Q - ${message.content.slice(0, 32)}`;
+		return `Q - ${message.content.slice(0, 22)}`;
 
 	const urlName = await getTitleFromUrl(url[0]);
 

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -62,15 +62,12 @@ export default event({
 	},
 });
 
-async function getThreadName(message: Message): Promise<string> {
+function getThreadName(message: Message): string | Promise<string> {
 	const url = message.content.match(urlRegex());
 
 	// If the channel isn't a link channel (i.e. a question one) or url can't be matched
 	if (!LINK_ONLY_CHANNELS.includes(message.channelId) || !url)
 		return `Q - ${message.content.slice(0, 22)}`;
 
-	const urlName = await getTitleFromUrl(url[0]);
-
-	// Return the urlname and fallback to discussion
-	return urlName || 'Discussion';
+	return getTitleFromUrl(url[0]);
 }

--- a/src/utils/unfurl.ts
+++ b/src/utils/unfurl.ts
@@ -1,6 +1,6 @@
 import { unfurl } from 'unfurl.js';
 
-export async function getTitleFromUrl(url: string): Promise<string> {
+export async function get_title_from_url(url: string): Promise<string> {
 	try {
 		const data = await unfurl(url, {
 			compress: true,

--- a/src/utils/unfurl.ts
+++ b/src/utils/unfurl.ts
@@ -1,0 +1,15 @@
+import { unfurl } from 'unfurl.js';
+
+export async function getTitleFromUrl(url: string) {
+	try {
+		const data = await unfurl(url, {
+			compress: true,
+			oembed: false,
+			timeout: 3500,
+		});
+
+		return data.open_graph.title || data.twitter_card.title || data.title;
+	} catch {
+		return url;
+	}
+}

--- a/src/utils/unfurl.ts
+++ b/src/utils/unfurl.ts
@@ -1,6 +1,6 @@
 import { unfurl } from 'unfurl.js';
 
-export async function getTitleFromUrl(url: string) {
+export async function getTitleFromUrl(url: string): Promise<string> {
 	try {
 		const data = await unfurl(url, {
 			compress: true,
@@ -8,7 +8,12 @@ export async function getTitleFromUrl(url: string) {
 			timeout: 3500,
 		});
 
-		return data.open_graph.title || data.twitter_card.title || data.title;
+		return (
+			data.open_graph.title ||
+			data.twitter_card.title ||
+			data.title ||
+			url
+		);
 	} catch {
 		return url;
 	}


### PR DESCRIPTION
There are two types of name generation here:

- If the thread is not limited to links only the format is `? - ${message.content.slice(0, 22)}`, this is so that if we ever do auto threadding in help channels there is no extra code needed

- If it is a link only channel the thread channel will be one of the following (checks in order): open graph title, twitter card title, document title, url

Lastly thread names are generated async so currently it will create the thread, then set the name. This is because fetching url data takes time. I wanna know opinions on this. Below is a gif of how it looks

![Peek 2022-02-02 16-48](https://user-images.githubusercontent.com/47755378/152199984-2667e4d8-b05a-4742-8c8c-6315aab119d7.gif)