### PR TITLE
Fix docs command

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@types/node": "^16.11.22",
 		"discord.js": "^13.6.0",
 		"dotenv": "^10.0.0",
+		"flexsearch": "^0.7.21",
 		"jellycommands": "1.0.0-next.19",
 		"js-trgm": "^1.0.2",
 		"node-fetch": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"url-regex": "^5.0.0"
 	},
 	"devDependencies": {
+		"@types/flexsearch": "^0.7.2",
 		"nodemon": "^2.0.15",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^2.5.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ specifiers:
   '@types/node': ^16.11.22
   discord.js: ^13.6.0
   dotenv: ^10.0.0
+  flexsearch: ^0.7.21
   jellycommands: 1.0.0-next.19
   js-trgm: ^1.0.2
   node-fetch: ^3.2.0
@@ -23,6 +24,7 @@ dependencies:
   '@types/node': 16.11.22
   discord.js: 13.6.0
   dotenv: 10.0.0
+  flexsearch: 0.7.21
   jellycommands: 1.0.0-next.19
   js-trgm: 1.0.2
   node-fetch: 3.2.0
@@ -635,6 +637,10 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
     dev: true
+
+  /flexsearch/0.7.21:
+    resolution: {integrity: sha512-W7cHV7Hrwjid6lWmy0IhsWDFQboWSng25U3VVywpHOTJnnAZNPScog67G+cVpeX9f7yDD21ih0WDrMMT+JoaYg==}
+    dev: false
 
   /follow-redirects/1.14.7:
     resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.3
 
 specifiers:
   '@supabase/supabase-js': ^1.30.0
+  '@types/flexsearch': ^0.7.2
   '@types/nice-try': ^2.1.0
   '@types/node': ^16.11.22
   discord.js: ^13.6.0
@@ -34,6 +35,7 @@ dependencies:
   url-regex: 5.0.0
 
 devDependencies:
+  '@types/flexsearch': 0.7.2
   nodemon: 2.0.15
   npm-run-all: 4.1.5
   prettier: 2.5.1
@@ -142,6 +144,10 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       defer-to-connect: 1.1.3
+    dev: true
+
+  /@types/flexsearch/0.7.2:
+    resolution: {integrity: sha512-Nq0CSpOCyUhaF7tAXSvMtoyBMPGlhNyF+uElhIrrgSiXDmX/bnn9jUX7Us3l81Hzowb9rcgNISke0Nj+3xhd3g==}
     dev: true
 
   /@types/nice-try/2.1.0:

--- a/src/commands/docs/_docs_cache.ts
+++ b/src/commands/docs/_docs_cache.ts
@@ -1,9 +1,24 @@
+import { trgm_search } from 'js-trgm';
 import fetch from 'node-fetch';
 import { Repos, RepositoryDetails } from '../../utils/repositories.js';
 
 export type ReposWithDocs = Repos.SVELTE | Repos.SVELTE_KIT;
 
 const cache = new Map<ReposWithDocs, Record<string, string>>();
+
+export async function search_docs(query: string, repo: ReposWithDocs) {
+	const cached_docs = await get_docs(repo);
+	const repo_details = RepositoryDetails[repo];
+
+	const results = trgm_search(query, Object.keys(cached_docs), {
+		limit: 5,
+	});
+
+	return results.map(
+		// prettier-ignore
+		(result) => `[${result.target}](${repo_details.DOCS_URL}${repo === Repos.SVELTE ? '#' : '/'}${cached_docs[result.target]})`,
+	);
+}
 
 /**
  * Get a `title: slug` record of sections of the Svelte or SvelteKit docs.

--- a/src/commands/docs/_docs_cache.ts
+++ b/src/commands/docs/_docs_cache.ts
@@ -22,9 +22,7 @@ async function build_cache(repo: ReposWithDocs) {
 		);
 	} else {
 		const response = await fetch('https://kit.svelte.dev/content.json');
-
 		blocks = ((await response.json()) as { blocks: Block[] }).blocks;
-		console.log(blocks);
 	}
 
 	// Build the index using the same settings as the site

--- a/src/commands/docs/_docs_cache.ts
+++ b/src/commands/docs/_docs_cache.ts
@@ -8,7 +8,7 @@ const cache = new Map<
 	ReposWithDocs,
 	{
 		index: flexsearch.Index;
-		lookup: Map<Block['href'], Block['breadcrumbs']>;
+		lookup: Map<Block['href'], string>;
 	}
 >();
 
@@ -30,11 +30,11 @@ async function build_cache(repo: ReposWithDocs) {
 	const index = new flexsearch.Index({
 		tokenize: 'forward',
 	});
-	const lookup = new Map<Block['href'], Block['breadcrumbs']>();
+	const lookup = new Map<Block['href'], string>();
 
 	for (const block of blocks) {
 		const title = block.breadcrumbs.at(-1);
-		lookup.set(block.href, [...block.breadcrumbs]);
+		lookup.set(block.href, block.breadcrumbs.join('/'));
 		index.add(block.href, `${title} ${block.content}`);
 	}
 
@@ -51,7 +51,7 @@ export async function search_docs(query: string, repo: ReposWithDocs) {
 	});
 
 	return results.map((href) => {
-		const link_text = lookup.get(href.toString())?.join('/');
+		const link_text = lookup.get(href.toString());
 		// prettier-ignore
 		const link = `${RepositoryDetails[repo].HOMEPAGE}${href.toString()}`;
 

--- a/src/commands/docs/docs.ts
+++ b/src/commands/docs/docs.ts
@@ -1,8 +1,8 @@
 import { command } from 'jellycommands';
-import { trgm_search } from 'js-trgm';
 import { build_embed, list_embed_builder } from '../../utils/embed_helpers.js';
+import { no_op } from '../../utils/promise.js';
 import { Repos, RepositoryDetails } from '../../utils/repositories.js';
-import { get_docs, ReposWithDocs, search_docs } from './_docs_cache.js';
+import { ReposWithDocs, search_docs } from './_docs_cache.js';
 
 export default command({
 	name: 'docs',
@@ -27,9 +27,9 @@ export default command({
 			required: true,
 		},
 		{
-			name: 'topic',
+			name: 'query',
 			type: 'STRING',
-			description: 'The topic to search for in the docs.',
+			description: 'The string to search for in the docs.',
 		},
 	],
 
@@ -40,35 +40,39 @@ export default command({
 		);
 
 		const repo_details = RepositoryDetails[repo];
-		const topic = interaction.options.getString('topic');
+		const query = interaction.options.getString('query');
 
 		try {
-			if (!topic)
+			if (!query)
 				return interaction.reply({
 					embeds: [
 						build_embed({
-							description: `[${repo_details.NAME} Docs](${repo_details.DOCS_URL})`,
+							description: `[${repo_details.NAME} Docs](${repo_details.HOMEPAGE}/docs)`,
 						}),
 					],
 				});
 
-			const results = await search_docs(topic, repo);
+			const results = await search_docs(query, repo);
 
-			if (results.length === 0)
+			if (!results.length)
 				return interaction.reply({
 					content:
 						'No matching result found. Try again with a different search term.',
 					ephemeral: true,
 				});
 
-			/** @todo Flexsearch (waiting for the svelte docs to move from api.svelte.dev) */
 			await interaction.reply({
 				embeds: [
 					list_embed_builder(results, `${repo_details.NAME} Docs`),
 				],
 			});
 		} catch {
-			// Do something with the errors
+			interaction
+				.reply({
+					content: 'An error occurred while searching the docs.',
+					ephemeral: true,
+				})
+				.catch(no_op);
 		}
 	},
 });

--- a/src/commands/docs/docs.ts
+++ b/src/commands/docs/docs.ts
@@ -2,7 +2,7 @@ import { command } from 'jellycommands';
 import { trgm_search } from 'js-trgm';
 import { build_embed, list_embed_builder } from '../../utils/embed_helpers.js';
 import { Repos, RepositoryDetails } from '../../utils/repositories.js';
-import { get_docs, ReposWithDocs } from './_docs_cache.js';
+import { get_docs, ReposWithDocs, search_docs } from './_docs_cache.js';
 
 export default command({
 	name: 'docs',
@@ -52,11 +52,7 @@ export default command({
 					],
 				});
 
-			const cached_docs = await get_docs(repo);
-
-			const results = trgm_search(topic, Object.keys(cached_docs), {
-				limit: 5,
-			});
+			const results = await search_docs(topic, repo);
 
 			if (results.length === 0)
 				return interaction.reply({
@@ -68,13 +64,7 @@ export default command({
 			/** @todo Flexsearch (waiting for the svelte docs to move from api.svelte.dev) */
 			await interaction.reply({
 				embeds: [
-					list_embed_builder(
-						results.map(
-							// prettier-ignore
-							(result) => `[${result.target}](${repo_details.DOCS_URL}${repo === Repos.SVELTE ? '#' : '/'}${cached_docs[result.target]})`,
-						),
-						`${repo_details.NAME} Docs`,
-					),
+					list_embed_builder(results, `${repo_details.NAME} Docs`),
 				],
 			});
 		} catch {

--- a/src/utils/repositories.ts
+++ b/src/utils/repositories.ts
@@ -9,13 +9,13 @@ export const RepositoryDetails: Record<Repos, RepoInfo> = {
 	1: {
 		NAME: 'Svelte',
 		DOCS_API_URL: 'https://api.svelte.dev/docs/svelte/docs',
-		DOCS_URL: 'https://svelte.dev/docs',
+		HOMEPAGE: 'https://svelte.dev',
 		REPOSITORY_NAME: 'sveltejs/svelte',
 	},
 	2: {
 		NAME: 'SvelteKit',
 		DOCS_API_URL: 'https://kit.svelte.dev/docs.json',
-		DOCS_URL: 'https://kit.svelte.dev/docs',
+		HOMEPAGE: 'https://kit.svelte.dev',
 		REPOSITORY_NAME: 'sveltejs/kit',
 	},
 	3: {
@@ -31,6 +31,6 @@ export const RepositoryDetails: Record<Repos, RepoInfo> = {
 interface RepoInfo {
 	NAME: string;
 	REPOSITORY_NAME: string;
-	DOCS_URL?: string;
+	HOMEPAGE?: string;
 	DOCS_API_URL?: string;
 }


### PR DESCRIPTION
Fixes docs links breaking because of https://github.com/sveltejs/kit/issues/3696

Uses flexsearch with identical settings for consistency with the results that'd appear on the site and because idk enough about flexsearch to decide whether different settings would be more suited for the interface we're providing compared to the reactive one provided on the site.