### PR TITLE
feat: update config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -77,6 +77,9 @@ const COMMUNITY_CHANNELS = [
 
 	// #library-announcements
 	'1060265526439456858',
+	
+	// #jobs
+	'640884695890133012',
 ];
 
 export const LINK_ONLY_CHANNELS = DEV_MODE

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,9 +77,6 @@ const COMMUNITY_CHANNELS = [
 
 	// #library-announcements
 	'1060265526439456858',
-	
-	// #jobs
-	'640884695890133012',
 ];
 
 export const LINK_ONLY_CHANNELS = DEV_MODE
@@ -100,5 +97,8 @@ export const AUTO_THREAD_CHANNELS = DEV_MODE
 			// #both-both-is-good
 			'919196322303725568',
 	  ]
-	: [...COMMUNITY_CHANNELS];
+	: [
+		...COMMUNITY_CHANNELS,
+		'640884695890133012', // jobs
+	];
 // #endregion


### PR DESCRIPTION
- Add #jobs channel to auto_thread list

Intent is to have new posts in #jobs open threads by default, to nudge users into responding within threads instead of on the main channel